### PR TITLE
ci: add repository-conventions gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id 'io.kestra.gradle.repository-conventions' version '1.2.3'
     id 'io.kestra.gradle.spotless-conventions' version '1.1.0'
     id "com.vanniktech.maven.publish" version "0.36.0"
     id "io.kestra.gradle.inject-bom-versions" version "1.1.0"
@@ -216,4 +217,3 @@ idea {
         downloadSources = true
     }
 }
-


### PR DESCRIPTION
Add the `io.kestra.gradle.repository-conventions` plugin (v1.2.3) to align with kestra-io conventions. Mirrors kestra-io/plugin-airflow@3954693.