### PR TITLE
fix(security): remediate OWASP/CWE audit findings (2026-06-30)

### DIFF
--- a/src/main/java/io/kestra/plugin/sifflet/RunRule.java
+++ b/src/main/java/io/kestra/plugin/sifflet/RunRule.java
@@ -59,6 +59,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 )
 public class RunRule extends Task implements RunnableTask<RunRule.Output> {
 
+    @ToString.Exclude
     @Schema(title = "Sifflet API key", description = "Bearer token for the Sifflet API; renderable and should be stored as a secret", required = true)
     @NotNull
     @PluginProperty(secret = true, group = "main")


### PR DESCRIPTION
## Summary

Remediates all findings (CRITICAL/HIGH/MEDIUM/LOW) from the 2026-06-30 automated security audit against OWASP Top 10 (2025), CWE Top 25, and OWASP ASVS Level 1.

## Findings Fixed

- **HIGH** — `@ToString` exposes `apiKey` in generated `toString()` output — `src/main/java/io/kestra/plugin/sifflet/RunRule.java:24` — Added `@ToString.Exclude` to the `apiKey` field so the Sifflet bearer token is no longer included in Lombok-generated `toString()` output (CWE-312 / CWE-532).

## Testing

- [ ] `./gradlew build` passes
- [ ] No regressions in existing tests

## References

- Security Audit EPIC: https://github.com/kestra-io/plugin-sifflet/issues/58
- [Full Audit Report](https://claude.ai/code/artifact/87ba8c38-c7ec-40ef-8d8e-384da1bfacf4)
- [Org-wide Security Meta-EPIC](https://github.com/kestra-io/kestra-ee/issues/9092)
